### PR TITLE
Fix selecting from autocomplete in empty textarea (fix #18)

### DIFF
--- a/modules/jush-textarea.js
+++ b/modules/jush-textarea.js
@@ -245,8 +245,10 @@ jush.textarea = (function () {
 			const offset = +acEl.options[acEl.selectedIndex].value;
 			forceNewUndo = true;
 			pre.lastPos = findSelPos(pre);
-			const start = findOffset(pre, pre.lastPos - offset);
-			range.setStart(start.container, start.offset);
+			if (range.startOffset) {
+				const start = findOffset(pre, pre.lastPos - offset);
+				range.setStart(start.container, start.offset);
+			}
 			document.execCommand('insertText', false, insert);
 			openAutocomplete(pre);
 		}


### PR DESCRIPTION
I don't fully understand those ranges, but this works for me.