### PR TITLE
fix #39

### DIFF
--- a/modules/jush-autocomplete-sql.js
+++ b/modules/jush-autocomplete-sql.js
@@ -86,12 +86,11 @@ jush.autocompleteSql = function (esc, tablesColumns) {
 			}
 		}
 
+		// escape columns and tables if necessary
+		allTables.forEach(addEsc);
+		columns.forEach(addEsc);
+		thisColumns.forEach(addEsc);
 		
-		if (!/^\w/.test(before)) { // escape columns and tables if necessary, unless the user starts typing letters
-			allTables.forEach(addEsc);
-			columns.forEach(addEsc);
-			thisColumns.forEach(addEsc);
-		}
 		
 		const ac = {};
 		for (const keywords of [preferred, keywordsDefault]) {
@@ -104,7 +103,7 @@ jush.autocompleteSql = function (esc, tablesColumns) {
 								continue;
 							}
 						}
-						if (keyword.length > before.length && keyword.toUpperCase().startsWith(before.toUpperCase())) {
+						if (keyword.length > before.length && keyword.toUpperCase().includes(before.toUpperCase())) {
 							const isCol = (keywords[re] == columns || keywords[re] == thisColumns);
 							ac[keyword + (isCol ? '' : ' ')] = before.length;
 						}
@@ -112,7 +111,6 @@ jush.autocompleteSql = function (esc, tablesColumns) {
 				}
 			}
 		}
-		
 		return ac;
 	}
 

--- a/modules/jush-autocomplete-sql.js
+++ b/modules/jush-autocomplete-sql.js
@@ -86,7 +86,8 @@ jush.autocompleteSql = function (esc, tablesColumns) {
 			}
 		}
 
-		if (query.includes(esc[0]) && !/^\w/.test(before)) { // if there's any ` in the query, use ` everywhere unless the user starts typing letters
+		
+		if (!/^\w/.test(before)) { // escape columns and tables if necessary, unless the user starts typing letters
 			allTables.forEach(addEsc);
 			columns.forEach(addEsc);
 			thisColumns.forEach(addEsc);
@@ -114,9 +115,12 @@ jush.autocompleteSql = function (esc, tablesColumns) {
 		
 		return ac;
 	}
-	
-	function addEsc(val, key, array) {
-		array[key] = esc[0] + val.replace(/\.?$/, esc[1] + '$&');
+
+	/** escape table names and column names if they contain special characters */
+	function addEsc(val, key, array){
+	  if (/[^A-Za-z0-9_]/.test(val)){
+	    array[key] = esc[0] + val.replace(/\.?$/, esc[1] + '$&');
+	  }
 	}
 
 	/** Change odd ` to esc[0], even to esc[1] */


### PR DESCRIPTION
Escape table names and column names as soon as they contain anything else than A-Z, a-z, 0-9, and underscore.